### PR TITLE
fix: ts中，event 变量已被标记为弃用,显示传递event方便维护

### DIFF
--- a/packages/src/index.vue
+++ b/packages/src/index.vue
@@ -59,7 +59,7 @@ export default {
   },
   methods: {
     // 实现移动端拖拽
-    down() {
+    down(event) {
       let moveDiv = document.querySelector("#pic");
       var touch;
       this.flag = true;
@@ -74,7 +74,7 @@ export default {
       this.dy = moveDiv.offsetTop; //上移量
       this.firstTime = new Date().getTime();
     },
-    move() {
+    move(event) {
       if (this.flag) {
         this.$emit("updateIsShowPop", false);
         let moveDiv = document.querySelector("#pic");


### PR DESCRIPTION
在 TypeScript 中，event 变量已被标记为弃用，这意味着它不再是推荐使用的方式，可能会在未来的版本中被移除；
推荐显式传递事件对象，让代码更加清晰和易于维护
使用全局 event弊端：命名冲突，全局变量容易与其他代码的变量产生冲突；可维护性差，现在javaScript和typeScript提供了更好的方案，例如通过事件监听器和回调函数